### PR TITLE
internal resume with nextjs implementation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
+        "source.fixAll.eslint": "explicit"
     },
     "editor.formatOnSave": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
             "name": "oba-next",
             "version": "0.1.0",
             "dependencies": {
+                "@mantine/core": "^8.3.13",
+                "@mantine/hooks": "^8.3.13",
                 "@next/font": "13.1.6",
                 "@sentry/nextjs": "^7.44.0",
                 "@types/node": "18.11.18",
@@ -21,12 +23,16 @@
                 "react": "18.2.0",
                 "react-dom": "18.2.0",
                 "react-icons": "^4.7.1",
-                "typescript": "4.9.5"
+                "styled-icons": "^10.47.1",
+                "typescript": "^5.3.3"
             },
             "devDependencies": {
                 "@typescript-eslint/eslint-plugin": "^5.52.0",
                 "eslint-config-prettier": "^8.6.0",
                 "prettier": "^2.8.4"
+            },
+            "engines": {
+                "node": ">=24.0.0"
             }
         },
         "node_modules/@babel/runtime": {
@@ -39,6 +45,27 @@
             "engines": {
                 "node": ">=6.9.0"
             }
+        },
+        "node_modules/@emotion/is-prop-valid": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+            "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+            "peer": true,
+            "dependencies": {
+                "@emotion/memoize": "^0.9.0"
+            }
+        },
+        "node_modules/@emotion/memoize": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+            "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+            "peer": true
+        },
+        "node_modules/@emotion/unitless": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+            "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+            "peer": true
         },
         "node_modules/@eslint/eslintrc": {
             "version": "1.4.1",
@@ -61,6 +88,54 @@
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
+        },
+        "node_modules/@floating-ui/core": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+            "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+            "dependencies": {
+                "@floating-ui/utils": "^0.2.10"
+            }
+        },
+        "node_modules/@floating-ui/dom": {
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+            "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+            "dependencies": {
+                "@floating-ui/core": "^1.7.3",
+                "@floating-ui/utils": "^0.2.10"
+            }
+        },
+        "node_modules/@floating-ui/react": {
+            "version": "0.27.16",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.16.tgz",
+            "integrity": "sha512-9O8N4SeG2z++TSM8QA/KTeKFBVCNEz/AGS7gWPJf6KFRzmRWixFRnCnkPHRDwSVZW6QPDO6uT0P2SpWNKCc9/g==",
+            "dependencies": {
+                "@floating-ui/react-dom": "^2.1.6",
+                "@floating-ui/utils": "^0.2.10",
+                "tabbable": "^6.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=17.0.0",
+                "react-dom": ">=17.0.0"
+            }
+        },
+        "node_modules/@floating-ui/react-dom": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
+            "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+            "dependencies": {
+                "@floating-ui/dom": "^1.7.4"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
+            }
+        },
+        "node_modules/@floating-ui/utils": {
+            "version": "0.2.10",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+            "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="
         },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.11.8",
@@ -96,6 +171,51 @@
             "version": "1.4.14",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
             "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+        },
+        "node_modules/@mantine/core": {
+            "version": "8.3.13",
+            "resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.3.13.tgz",
+            "integrity": "sha512-ZgW4vqN4meaPyIMxzAufBvsgmJRfYZdTpsrAOcS8pWy7m9e8i685E7XsAxnwJCOIHudpvpvt+7Bx7VaIjEsYEw==",
+            "dependencies": {
+                "@floating-ui/react": "^0.27.16",
+                "clsx": "^2.1.1",
+                "react-number-format": "^5.4.4",
+                "react-remove-scroll": "^2.7.1",
+                "react-textarea-autosize": "8.5.9",
+                "type-fest": "^4.41.0"
+            },
+            "peerDependencies": {
+                "@mantine/hooks": "8.3.13",
+                "react": "^18.x || ^19.x",
+                "react-dom": "^18.x || ^19.x"
+            }
+        },
+        "node_modules/@mantine/core/node_modules/clsx": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@mantine/core/node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@mantine/hooks": {
+            "version": "8.3.13",
+            "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-8.3.13.tgz",
+            "integrity": "sha512-7YMbMW/tR9E8m/9DbBW01+3RNApm2mE/JbRKXf9s9+KxgbjQvq0FYGWV8Y4+Sjz48AO4vtWk2qBriUTgBMKAyg==",
+            "peerDependencies": {
+                "react": "^18.x || ^19.x"
+            }
         },
         "node_modules/@next/env": {
             "version": "13.1.6",
@@ -701,6 +821,634 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@styled-icons/bootstrap": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/bootstrap/-/bootstrap-10.47.0.tgz",
+            "integrity": "sha512-xpnPdrLhAhpTRE4iljQIEK73twVj7VPglwHSL+8nQdH7EsW5RJIOWsmlkZMyqhQHN0H7fGmT10F3/6OQhSpfGg==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/boxicons-logos": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-logos/-/boxicons-logos-10.47.0.tgz",
+            "integrity": "sha512-eDZfiTjBth4MsCX83ZfiWIoYGU494NxZgAxyf7S0ky2ZRsJnq/Cs7crH4hKWUTaLvCo0XRJmLeA3Us2tZFiItg==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/boxicons-regular": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-regular/-/boxicons-regular-10.47.0.tgz",
+            "integrity": "sha512-z8KczDp4VArXvOn8i2j66Xs4oX9oiiJEhMoHydY3uC9kdtImcxhZ/xHPrgTJLkbK6f5ikwB4CKVnSqQGzzAJNw==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/boxicons-solid": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-solid/-/boxicons-solid-10.47.0.tgz",
+            "integrity": "sha512-M795TXYtSJCpfr+ukHZfH9mA0j5MPlB5vwRCnU3O+dojAYla/zoaSashjhUbmlgzKNwALWNfzOqicSCAzU2fhg==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/crypto": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/crypto/-/crypto-10.47.0.tgz",
+            "integrity": "sha512-2hSOo1yb3ZEEOJAv9OBZLf3KQ8ujJrLw1uVDINJa7zLGuSfEWawnlkv/T2B0zQkOm0Hb6gikTRTAkLr4gyIS4Q==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/entypo": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/entypo/-/entypo-10.46.0.tgz",
+            "integrity": "sha512-0ChIqx3EMlMeout4Aa5AwEYtKsgTqrY/NnVQGvhlGfMYq9mC7jq7JuaKvt5SJ9/0cEnVhgW5zwAe4LeyrsJl5g==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/entypo-social": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/entypo-social/-/entypo-social-10.46.0.tgz",
+            "integrity": "sha512-DWbUK7JkuAu4TPIBeeYfxys3cP8M4/q/XG2JVruDHa18viCEcDR1JXfn1p3TVYZCvlciKev+Vr1yrgcamTwVkg==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/evaicons-outline": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/evaicons-outline/-/evaicons-outline-10.46.0.tgz",
+            "integrity": "sha512-+tHb/Ir6G1e+rSJ2YKgm2vzjF80JoXWEmoC48exFrQEKQkJPSWtsqKdROkfANKrY9AFnRKhJQ+9fHhnjS+V/OA==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/evaicons-solid": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/evaicons-solid/-/evaicons-solid-10.46.0.tgz",
+            "integrity": "sha512-tRw2/TkmRNV4N2badKPFnnRy+WbVtUkrloNo94CgF5rpxoL0eK+ki3OYZYqbl0T66bJ07hqduqTc3rbxvT/vfw==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/evil": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/evil/-/evil-10.46.0.tgz",
+            "integrity": "sha512-r1g2jZmz84XGLgJbAPkMDmuToUF+KyNWkS6GNoP+ygzriNgzgoHkcEvIb/bx/I2/UUHeotRMOknvhvh5C2CwFg==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/fa-brands": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/fa-brands/-/fa-brands-10.47.0.tgz",
+            "integrity": "sha512-w+G31+61nBnjxzCwMs+H9rNm9jl+HhtRgZYvNd+2NKQn1dRbHbBVXzQEHCOL6hksvkDbIa0iPrenqMU6pB+wZQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/fa-regular": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/fa-regular/-/fa-regular-10.47.0.tgz",
+            "integrity": "sha512-UL/MwhwlJ5SbcioI+UBR8KocYt6i+20akKn1ZNj0Pjgm2kv2odEJSWWkHCxh8J7T7s0q/Wvs3CMsBTMrKdKDpQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/fa-solid": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/fa-solid/-/fa-solid-10.47.0.tgz",
+            "integrity": "sha512-8AJjbOAkvPlB/ypFzWo++CZxRDlFQfvWQSjWzVU/v/4kjGRWIiVB+rJrTB7joDUd5Oas/se4cSiDkSA+XR/Fqg==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/feather": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/feather/-/feather-10.47.0.tgz",
+            "integrity": "sha512-w6F3s1B4DaQGLr4AZZ0PffZQOnPSRqr3npHoTvk4Juz4uTjw9/oHolcrTxPyJas9gXAV1kCLbeiaxTR6JVxJPw==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/fluentui-system-filled": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/fluentui-system-filled/-/fluentui-system-filled-10.47.0.tgz",
+            "integrity": "sha512-jAO8bs9SY/5Xu2vxg5sJmnD5YA966G2m2qU4ezlDbLDIXSaX/1qUBUivBFSWCDn4q5rslegzD1rhc9FncgPbSw==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/fluentui-system-regular": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/fluentui-system-regular/-/fluentui-system-regular-10.47.0.tgz",
+            "integrity": "sha512-x1TmxKS6mpX+QJw8ismT3rNa6TPvKYftmQRy57LbdNE9L5FkyWldrumPboZGKWi/oNiBn6SBelPeqv8LPFXNHQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/foundation": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/foundation/-/foundation-10.46.0.tgz",
+            "integrity": "sha512-RZqNVxStjvboGg6+X1By9pE0j7FuzUkfgbu9SgOkSzMrHTvnTOu0JiQ7nNw+CY46rXhT8JTwRCgk2OLTk+anGA==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/heroicons-outline": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/heroicons-outline/-/heroicons-outline-10.47.0.tgz",
+            "integrity": "sha512-C7bcJ/YPVKACoQLSBDM9DkgmrO1HmqAaru9kqYK2V+GaGUW5raf6dyTLo7GUYt/CJ7p3qWxsBz3SX6djzdaODQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/heroicons-solid": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/heroicons-solid/-/heroicons-solid-10.47.0.tgz",
+            "integrity": "sha512-j+tJx2NzLG2tc91IXJVwKNjsI/osxmak+wmLfnfBsB+49srpxMYjuLPMtl9ZY/xgbNsWO36O+/N5Zf5bkgiKcQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/icomoon": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/icomoon/-/icomoon-10.46.0.tgz",
+            "integrity": "sha512-3KcTTuswDrC03byyr9G9v5aWDTrhO6PbbN5O7CtU4/NXY4AaOkTQ8GUfvRjZ8yG/aEYRH4VYkWFpYu1CdsZxNg==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/ionicons-outline": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-outline/-/ionicons-outline-10.46.0.tgz",
+            "integrity": "sha512-BEFEBGQDhPssEshbHyrsAXbEb7hNsrsHa0Zh0zLlfCIB3Vxc2GrQU9Qibto443ZRVw5qgF7iBdSwQHiwY8dQJw==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/ionicons-sharp": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-sharp/-/ionicons-sharp-10.46.0.tgz",
+            "integrity": "sha512-ZMkS+zBe04odi/4llkKMZkNEz8K3whta7Chzk81vvCTtR7jMnGEyw+tMUZbARliOOyaELBeTbgeUwNRNTibiSA==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/ionicons-solid": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-solid/-/ionicons-solid-10.46.0.tgz",
+            "integrity": "sha512-agiuzQzqrrRWHrGfswC6EciKVjt/XSZuQFbvP/s6qU2oYkQuJRdhmAZQldTaj9Xb2GyAmEjM0cmkWG3+JzV7CQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/material": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/material/-/material-10.47.0.tgz",
+            "integrity": "sha512-6fwoLPHg3P9O/iXSblQ67mchgURJvhU7mfba29ICfpg62zJ/loEalUgspm1GGtYVSPtkejshVWUtV99dXpcQfg==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/material-outlined": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/material-outlined/-/material-outlined-10.47.0.tgz",
+            "integrity": "sha512-/QeDSGXlfRoIsgx4g4Hb//xhsucD4mJJsNPk/e1XzckxkNG+YHCIjbAHzDwxwNfSCJYcTDcOp2SZcoS7iyNGlw==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/material-rounded": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/material-rounded/-/material-rounded-10.47.0.tgz",
+            "integrity": "sha512-+ByhDd1FJept3k8iBDxMWSzmIh29UrgZTIzh2pADWldGrsD/2JKdsC7knQghSj9uCevHNMKEeVaYBQMLoNUjvw==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/material-sharp": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/material-sharp/-/material-sharp-10.47.0.tgz",
+            "integrity": "sha512-U9bjvur/vawfiBhE75efNOF4WkSAygn26bQvHFJPc71ZCisvgJncnlSmR0rUgWnu7Cp/qg6faDH5CKDXBmGWCA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/material-twotone": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/material-twotone/-/material-twotone-10.47.0.tgz",
+            "integrity": "sha512-c4Q1r0EJaDEI1/IsBWo0Mo8lZZvtA/3Or1ScUcmjwKBZxpR8960uGy4CReLzBPALC4L6aPiM1H168fz39fm4oQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/octicons": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/octicons/-/octicons-10.47.0.tgz",
+            "integrity": "sha512-JOqEbwbh23u/AdaINod8ZeVN5MEcOvkSeMTwGIPaPgz5PNuWRj/+1LpixmBeZjAr/WhB0pxZBBwA+e91BelQCA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/open-iconic": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/open-iconic/-/open-iconic-10.46.0.tgz",
+            "integrity": "sha512-v7wrHcUACQeSfJrLan/jXxgz7RSlJJXSc2u33UR82ewkOSBhaXp/zZxKF1tFCT2spvth0NBl6OkZUCw9ctgyrA==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/remix-editor": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/remix-editor/-/remix-editor-10.46.0.tgz",
+            "integrity": "sha512-oOrt6wj5//4LrZkm40bXcsFpTgXbdOkixu6RHuE3O82+Hqtw1bYR/smm5MbLOJ+Kz62SEjDF3sxqFO23ITDeUQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/remix-fill": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/remix-fill/-/remix-fill-10.46.0.tgz",
+            "integrity": "sha512-D2rWGJ9/7BR+3TMvmIoWGASMfyhWT4lTF+we8h9Pya5Ye+69cftvp817DMuaR/6czCugXTrB++HTQX0XJfoBFw==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/remix-line": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/remix-line/-/remix-line-10.46.0.tgz",
+            "integrity": "sha512-TkbtXdgcuM7VpE/51k8+sxfReFjSQpAFVnjJi8/gxwcTzjdOG7Plkgsaixi2+hiLk/Coj/+67KbntBoSevROsw==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/simple-icons": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/simple-icons/-/simple-icons-10.46.0.tgz",
+            "integrity": "sha512-zHkbGqAqFOwpqDjbhKTKsAXNxtBOXb7Ot2eKoDaDFckJGr2shAXRchclUS6wSixSPwQIPGAUcdO7Cq744Ollng==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/styled-icon": {
+            "version": "10.7.1",
+            "resolved": "https://registry.npmjs.org/@styled-icons/styled-icon/-/styled-icon-10.7.1.tgz",
+            "integrity": "sha512-WLYaeMTMhMkSxE+v+of+r2ovIk0tceDGfv8iqWHRMxvbm+6zxngVcQ4ELx6Zt/LFxqckmmoAdvo6ehiiYj6I6A==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.7"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": ">=4.1.0"
+            }
+        },
+        "node_modules/@styled-icons/typicons": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/typicons/-/typicons-10.46.0.tgz",
+            "integrity": "sha512-yCJnVggGsbxOyuIPEmD+9IYRvB5w41hpJKdpI0ErasYG9Izt/lGqUaaDaxR39u9s28Q54Fq/v+Ni17dFCs8FOw==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
+        "node_modules/@styled-icons/zondicons": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/zondicons/-/zondicons-10.46.0.tgz",
+            "integrity": "sha512-DUlww6TeFsFjHD/1qd+DtMutm44r3ssOYtPiMJrOVolX1NqdW6XzrJ5dTbVCA2s7Ucd+Vp25cWfXnLcJBfas3w==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": "*"
+            }
+        },
         "node_modules/@swc/helpers": {
             "version": "0.4.14",
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
@@ -763,6 +1511,12 @@
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
             "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
             "dev": true
+        },
+        "node_modules/@types/stylis": {
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.7.tgz",
+            "integrity": "sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==",
+            "peer": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "5.52.0",
@@ -1413,6 +2167,15 @@
                 "node": ">=6"
             }
         },
+        "node_modules/camelize": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+            "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+            "peer": true,
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/caniuse-lite": {
             "version": "1.0.30001449",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001449.tgz",
@@ -1503,10 +2266,30 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/css-color-keywords": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+            "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+            "peer": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/css-to-react-native": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+            "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+            "peer": true,
+            "dependencies": {
+                "camelize": "^1.0.0",
+                "css-color-keywords": "^1.0.0",
+                "postcss-value-parser": "^4.0.2"
+            }
+        },
         "node_modules/csstype": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-            "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
         },
         "node_modules/damerau-levenshtein": {
             "version": "1.0.8",
@@ -1583,6 +2366,11 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/detect-node-es": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+            "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
         },
         "node_modules/dir-glob": {
             "version": "3.0.1",
@@ -2363,6 +3151,14 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-nonce": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+            "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/get-symbol-description": {
@@ -3177,9 +3973,15 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/nanoid": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -3498,9 +4300,9 @@
             }
         },
         "node_modules/picocolors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -3535,6 +4337,12 @@
             "engines": {
                 "node": "^10 || ^12 || >=14"
             }
+        },
+        "node_modules/postcss-value-parser": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+            "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+            "peer": true
         },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
@@ -3644,6 +4452,97 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "node_modules/react-number-format": {
+            "version": "5.4.4",
+            "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.4.4.tgz",
+            "integrity": "sha512-wOmoNZoOpvMminhifQYiYSTCLUDOiUbBunrMrMjA+dV52sY+vck1S4UhR6PkgnoCquvvMSeJjErXZ4qSaWCliA==",
+            "peerDependencies": {
+                "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/react-remove-scroll": {
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+            "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+            "dependencies": {
+                "react-remove-scroll-bar": "^2.3.7",
+                "react-style-singleton": "^2.2.3",
+                "tslib": "^2.1.0",
+                "use-callback-ref": "^1.3.3",
+                "use-sidecar": "^1.1.3"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/react-remove-scroll-bar": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+            "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+            "dependencies": {
+                "react-style-singleton": "^2.2.2",
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/react-style-singleton": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+            "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+            "dependencies": {
+                "get-nonce": "^1.0.0",
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/react-textarea-autosize": {
+            "version": "8.5.9",
+            "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
+            "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "use-composed-ref": "^1.3.0",
+                "use-latest": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
         },
         "node_modules/regenerator-runtime": {
             "version": "0.13.11",
@@ -3795,6 +4694,12 @@
                 "node": ">=10"
             }
         },
+        "node_modules/shallowequal": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+            "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+            "peer": true
+        },
         "node_modules/shebang-command": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -3836,9 +4741,9 @@
             }
         },
         "node_modules/source-map-js": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3947,6 +4852,120 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/styled-components": {
+            "version": "6.3.8",
+            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.3.8.tgz",
+            "integrity": "sha512-Kq/W41AKQloOqKM39zfaMdJ4BcYDw/N5CIq4/GTI0YjU6pKcZ1KKhk6b4du0a+6RA9pIfOP/eu94Ge7cu+PDCA==",
+            "peer": true,
+            "dependencies": {
+                "@emotion/is-prop-valid": "1.4.0",
+                "@emotion/unitless": "0.10.0",
+                "@types/stylis": "4.2.7",
+                "css-to-react-native": "3.2.0",
+                "csstype": "3.2.3",
+                "postcss": "8.4.49",
+                "shallowequal": "1.1.0",
+                "stylis": "4.3.6",
+                "tslib": "2.8.1"
+            },
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/styled-components"
+            },
+            "peerDependencies": {
+                "react": ">= 16.8.0",
+                "react-dom": ">= 16.8.0"
+            },
+            "peerDependenciesMeta": {
+                "react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/styled-components/node_modules/postcss": {
+            "version": "8.4.49",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+            "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "peer": true,
+            "dependencies": {
+                "nanoid": "^3.3.7",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/styled-icons": {
+            "version": "10.47.1",
+            "resolved": "https://registry.npmjs.org/styled-icons/-/styled-icons-10.47.1.tgz",
+            "integrity": "sha512-O6SguU8Z8Qk+rWJkiPmoLOxCQ3x8Emabue2r4NPqX+CK1uyaNahzFtKaGq/0d13RTWXqfVOBUSIJZaIlu4G/CA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/bootstrap": "10.47.0",
+                "@styled-icons/boxicons-logos": "10.47.0",
+                "@styled-icons/boxicons-regular": "10.47.0",
+                "@styled-icons/boxicons-solid": "10.47.0",
+                "@styled-icons/crypto": "10.47.0",
+                "@styled-icons/entypo": "10.46.0",
+                "@styled-icons/entypo-social": "10.46.0",
+                "@styled-icons/evaicons-outline": "10.46.0",
+                "@styled-icons/evaicons-solid": "10.46.0",
+                "@styled-icons/evil": "10.46.0",
+                "@styled-icons/fa-brands": "10.47.0",
+                "@styled-icons/fa-regular": "10.47.0",
+                "@styled-icons/fa-solid": "10.47.0",
+                "@styled-icons/feather": "10.47.0",
+                "@styled-icons/fluentui-system-filled": "10.47.0",
+                "@styled-icons/fluentui-system-regular": "10.47.0",
+                "@styled-icons/foundation": "10.46.0",
+                "@styled-icons/heroicons-outline": "10.47.0",
+                "@styled-icons/heroicons-solid": "10.47.0",
+                "@styled-icons/icomoon": "10.46.0",
+                "@styled-icons/ionicons-outline": "10.46.0",
+                "@styled-icons/ionicons-sharp": "10.46.0",
+                "@styled-icons/ionicons-solid": "10.46.0",
+                "@styled-icons/material": "10.47.0",
+                "@styled-icons/material-outlined": "10.47.0",
+                "@styled-icons/material-rounded": "10.47.0",
+                "@styled-icons/material-sharp": "10.47.0",
+                "@styled-icons/material-twotone": "10.47.0",
+                "@styled-icons/octicons": "10.47.0",
+                "@styled-icons/open-iconic": "10.46.0",
+                "@styled-icons/remix-editor": "10.46.0",
+                "@styled-icons/remix-fill": "10.46.0",
+                "@styled-icons/remix-line": "10.46.0",
+                "@styled-icons/simple-icons": "10.46.0",
+                "@styled-icons/styled-icon": "10.7.1",
+                "@styled-icons/typicons": "10.46.0",
+                "@styled-icons/zondicons": "10.46.0"
+            },
+            "funding": {
+                "type": "GitHub",
+                "url": "https://github.com/sponsors/jacobwgillespie"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "styled-components": ">=4.1.0"
+            }
+        },
         "node_modules/styled-jsx": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
@@ -3968,6 +4987,12 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/stylis": {
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+            "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+            "peer": true
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
@@ -4005,6 +5030,11 @@
             "funding": {
                 "url": "https://opencollective.com/unts"
             }
+        },
+        "node_modules/tabbable": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+            "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="
         },
         "node_modules/tapable": {
             "version": "2.2.1",
@@ -4056,9 +5086,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "node_modules/tsutils": {
             "version": "3.21.0",
@@ -4115,15 +5145,15 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=14.17"
             }
         },
         "node_modules/unbox-primitive": {
@@ -4146,6 +5176,89 @@
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dependencies": {
                 "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/use-callback-ref": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+            "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/use-composed-ref": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
+            "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/use-isomorphic-layout-effect": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+            "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/use-latest": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
+            "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
+            "dependencies": {
+                "use-isomorphic-layout-effect": "^1.1.1"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/use-sidecar": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+            "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+            "dependencies": {
+                "detect-node-es": "^1.1.0",
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
             }
         },
         "node_modules/webidl-conversions": {
@@ -4271,6 +5384,27 @@
                 "regenerator-runtime": "^0.13.11"
             }
         },
+        "@emotion/is-prop-valid": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+            "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+            "peer": true,
+            "requires": {
+                "@emotion/memoize": "^0.9.0"
+            }
+        },
+        "@emotion/memoize": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+            "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+            "peer": true
+        },
+        "@emotion/unitless": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+            "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+            "peer": true
+        },
         "@eslint/eslintrc": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
@@ -4286,6 +5420,46 @@
                 "minimatch": "^3.1.2",
                 "strip-json-comments": "^3.1.1"
             }
+        },
+        "@floating-ui/core": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+            "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+            "requires": {
+                "@floating-ui/utils": "^0.2.10"
+            }
+        },
+        "@floating-ui/dom": {
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+            "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+            "requires": {
+                "@floating-ui/core": "^1.7.3",
+                "@floating-ui/utils": "^0.2.10"
+            }
+        },
+        "@floating-ui/react": {
+            "version": "0.27.16",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.16.tgz",
+            "integrity": "sha512-9O8N4SeG2z++TSM8QA/KTeKFBVCNEz/AGS7gWPJf6KFRzmRWixFRnCnkPHRDwSVZW6QPDO6uT0P2SpWNKCc9/g==",
+            "requires": {
+                "@floating-ui/react-dom": "^2.1.6",
+                "@floating-ui/utils": "^0.2.10",
+                "tabbable": "^6.0.0"
+            }
+        },
+        "@floating-ui/react-dom": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
+            "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+            "requires": {
+                "@floating-ui/dom": "^1.7.4"
+            }
+        },
+        "@floating-ui/utils": {
+            "version": "0.2.10",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+            "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="
         },
         "@humanwhocodes/config-array": {
             "version": "0.11.8",
@@ -4311,6 +5485,37 @@
             "version": "1.4.14",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
             "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+        },
+        "@mantine/core": {
+            "version": "8.3.13",
+            "resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.3.13.tgz",
+            "integrity": "sha512-ZgW4vqN4meaPyIMxzAufBvsgmJRfYZdTpsrAOcS8pWy7m9e8i685E7XsAxnwJCOIHudpvpvt+7Bx7VaIjEsYEw==",
+            "requires": {
+                "@floating-ui/react": "^0.27.16",
+                "clsx": "^2.1.1",
+                "react-number-format": "^5.4.4",
+                "react-remove-scroll": "^2.7.1",
+                "react-textarea-autosize": "8.5.9",
+                "type-fest": "^4.41.0"
+            },
+            "dependencies": {
+                "clsx": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+                    "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
+                },
+                "type-fest": {
+                    "version": "4.41.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+                    "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="
+                }
+            }
+        },
+        "@mantine/hooks": {
+            "version": "8.3.13",
+            "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-8.3.13.tgz",
+            "integrity": "sha512-7YMbMW/tR9E8m/9DbBW01+3RNApm2mE/JbRKXf9s9+KxgbjQvq0FYGWV8Y4+Sjz48AO4vtWk2qBriUTgBMKAyg==",
+            "requires": {}
         },
         "@next/env": {
             "version": "13.1.6",
@@ -4712,6 +5917,338 @@
                 "webpack-sources": "^2.0.0 || ^3.0.0"
             }
         },
+        "@styled-icons/bootstrap": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/bootstrap/-/bootstrap-10.47.0.tgz",
+            "integrity": "sha512-xpnPdrLhAhpTRE4iljQIEK73twVj7VPglwHSL+8nQdH7EsW5RJIOWsmlkZMyqhQHN0H7fGmT10F3/6OQhSpfGg==",
+            "requires": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/boxicons-logos": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-logos/-/boxicons-logos-10.47.0.tgz",
+            "integrity": "sha512-eDZfiTjBth4MsCX83ZfiWIoYGU494NxZgAxyf7S0ky2ZRsJnq/Cs7crH4hKWUTaLvCo0XRJmLeA3Us2tZFiItg==",
+            "requires": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/boxicons-regular": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-regular/-/boxicons-regular-10.47.0.tgz",
+            "integrity": "sha512-z8KczDp4VArXvOn8i2j66Xs4oX9oiiJEhMoHydY3uC9kdtImcxhZ/xHPrgTJLkbK6f5ikwB4CKVnSqQGzzAJNw==",
+            "requires": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/boxicons-solid": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-solid/-/boxicons-solid-10.47.0.tgz",
+            "integrity": "sha512-M795TXYtSJCpfr+ukHZfH9mA0j5MPlB5vwRCnU3O+dojAYla/zoaSashjhUbmlgzKNwALWNfzOqicSCAzU2fhg==",
+            "requires": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/crypto": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/crypto/-/crypto-10.47.0.tgz",
+            "integrity": "sha512-2hSOo1yb3ZEEOJAv9OBZLf3KQ8ujJrLw1uVDINJa7zLGuSfEWawnlkv/T2B0zQkOm0Hb6gikTRTAkLr4gyIS4Q==",
+            "requires": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/entypo": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/entypo/-/entypo-10.46.0.tgz",
+            "integrity": "sha512-0ChIqx3EMlMeout4Aa5AwEYtKsgTqrY/NnVQGvhlGfMYq9mC7jq7JuaKvt5SJ9/0cEnVhgW5zwAe4LeyrsJl5g==",
+            "requires": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/entypo-social": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/entypo-social/-/entypo-social-10.46.0.tgz",
+            "integrity": "sha512-DWbUK7JkuAu4TPIBeeYfxys3cP8M4/q/XG2JVruDHa18viCEcDR1JXfn1p3TVYZCvlciKev+Vr1yrgcamTwVkg==",
+            "requires": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/evaicons-outline": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/evaicons-outline/-/evaicons-outline-10.46.0.tgz",
+            "integrity": "sha512-+tHb/Ir6G1e+rSJ2YKgm2vzjF80JoXWEmoC48exFrQEKQkJPSWtsqKdROkfANKrY9AFnRKhJQ+9fHhnjS+V/OA==",
+            "requires": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/evaicons-solid": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/evaicons-solid/-/evaicons-solid-10.46.0.tgz",
+            "integrity": "sha512-tRw2/TkmRNV4N2badKPFnnRy+WbVtUkrloNo94CgF5rpxoL0eK+ki3OYZYqbl0T66bJ07hqduqTc3rbxvT/vfw==",
+            "requires": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/evil": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/evil/-/evil-10.46.0.tgz",
+            "integrity": "sha512-r1g2jZmz84XGLgJbAPkMDmuToUF+KyNWkS6GNoP+ygzriNgzgoHkcEvIb/bx/I2/UUHeotRMOknvhvh5C2CwFg==",
+            "requires": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/fa-brands": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/fa-brands/-/fa-brands-10.47.0.tgz",
+            "integrity": "sha512-w+G31+61nBnjxzCwMs+H9rNm9jl+HhtRgZYvNd+2NKQn1dRbHbBVXzQEHCOL6hksvkDbIa0iPrenqMU6pB+wZQ==",
+            "requires": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/fa-regular": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/fa-regular/-/fa-regular-10.47.0.tgz",
+            "integrity": "sha512-UL/MwhwlJ5SbcioI+UBR8KocYt6i+20akKn1ZNj0Pjgm2kv2odEJSWWkHCxh8J7T7s0q/Wvs3CMsBTMrKdKDpQ==",
+            "requires": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/fa-solid": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/fa-solid/-/fa-solid-10.47.0.tgz",
+            "integrity": "sha512-8AJjbOAkvPlB/ypFzWo++CZxRDlFQfvWQSjWzVU/v/4kjGRWIiVB+rJrTB7joDUd5Oas/se4cSiDkSA+XR/Fqg==",
+            "requires": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/feather": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/feather/-/feather-10.47.0.tgz",
+            "integrity": "sha512-w6F3s1B4DaQGLr4AZZ0PffZQOnPSRqr3npHoTvk4Juz4uTjw9/oHolcrTxPyJas9gXAV1kCLbeiaxTR6JVxJPw==",
+            "requires": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/fluentui-system-filled": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/fluentui-system-filled/-/fluentui-system-filled-10.47.0.tgz",
+            "integrity": "sha512-jAO8bs9SY/5Xu2vxg5sJmnD5YA966G2m2qU4ezlDbLDIXSaX/1qUBUivBFSWCDn4q5rslegzD1rhc9FncgPbSw==",
+            "requires": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/fluentui-system-regular": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/fluentui-system-regular/-/fluentui-system-regular-10.47.0.tgz",
+            "integrity": "sha512-x1TmxKS6mpX+QJw8ismT3rNa6TPvKYftmQRy57LbdNE9L5FkyWldrumPboZGKWi/oNiBn6SBelPeqv8LPFXNHQ==",
+            "requires": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/foundation": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/foundation/-/foundation-10.46.0.tgz",
+            "integrity": "sha512-RZqNVxStjvboGg6+X1By9pE0j7FuzUkfgbu9SgOkSzMrHTvnTOu0JiQ7nNw+CY46rXhT8JTwRCgk2OLTk+anGA==",
+            "requires": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/heroicons-outline": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/heroicons-outline/-/heroicons-outline-10.47.0.tgz",
+            "integrity": "sha512-C7bcJ/YPVKACoQLSBDM9DkgmrO1HmqAaru9kqYK2V+GaGUW5raf6dyTLo7GUYt/CJ7p3qWxsBz3SX6djzdaODQ==",
+            "requires": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/heroicons-solid": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/heroicons-solid/-/heroicons-solid-10.47.0.tgz",
+            "integrity": "sha512-j+tJx2NzLG2tc91IXJVwKNjsI/osxmak+wmLfnfBsB+49srpxMYjuLPMtl9ZY/xgbNsWO36O+/N5Zf5bkgiKcQ==",
+            "requires": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/icomoon": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/icomoon/-/icomoon-10.46.0.tgz",
+            "integrity": "sha512-3KcTTuswDrC03byyr9G9v5aWDTrhO6PbbN5O7CtU4/NXY4AaOkTQ8GUfvRjZ8yG/aEYRH4VYkWFpYu1CdsZxNg==",
+            "requires": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/ionicons-outline": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-outline/-/ionicons-outline-10.46.0.tgz",
+            "integrity": "sha512-BEFEBGQDhPssEshbHyrsAXbEb7hNsrsHa0Zh0zLlfCIB3Vxc2GrQU9Qibto443ZRVw5qgF7iBdSwQHiwY8dQJw==",
+            "requires": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/ionicons-sharp": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-sharp/-/ionicons-sharp-10.46.0.tgz",
+            "integrity": "sha512-ZMkS+zBe04odi/4llkKMZkNEz8K3whta7Chzk81vvCTtR7jMnGEyw+tMUZbARliOOyaELBeTbgeUwNRNTibiSA==",
+            "requires": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/ionicons-solid": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-solid/-/ionicons-solid-10.46.0.tgz",
+            "integrity": "sha512-agiuzQzqrrRWHrGfswC6EciKVjt/XSZuQFbvP/s6qU2oYkQuJRdhmAZQldTaj9Xb2GyAmEjM0cmkWG3+JzV7CQ==",
+            "requires": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/material": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/material/-/material-10.47.0.tgz",
+            "integrity": "sha512-6fwoLPHg3P9O/iXSblQ67mchgURJvhU7mfba29ICfpg62zJ/loEalUgspm1GGtYVSPtkejshVWUtV99dXpcQfg==",
+            "requires": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/material-outlined": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/material-outlined/-/material-outlined-10.47.0.tgz",
+            "integrity": "sha512-/QeDSGXlfRoIsgx4g4Hb//xhsucD4mJJsNPk/e1XzckxkNG+YHCIjbAHzDwxwNfSCJYcTDcOp2SZcoS7iyNGlw==",
+            "requires": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/material-rounded": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/material-rounded/-/material-rounded-10.47.0.tgz",
+            "integrity": "sha512-+ByhDd1FJept3k8iBDxMWSzmIh29UrgZTIzh2pADWldGrsD/2JKdsC7knQghSj9uCevHNMKEeVaYBQMLoNUjvw==",
+            "requires": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/material-sharp": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/material-sharp/-/material-sharp-10.47.0.tgz",
+            "integrity": "sha512-U9bjvur/vawfiBhE75efNOF4WkSAygn26bQvHFJPc71ZCisvgJncnlSmR0rUgWnu7Cp/qg6faDH5CKDXBmGWCA==",
+            "requires": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/material-twotone": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/material-twotone/-/material-twotone-10.47.0.tgz",
+            "integrity": "sha512-c4Q1r0EJaDEI1/IsBWo0Mo8lZZvtA/3Or1ScUcmjwKBZxpR8960uGy4CReLzBPALC4L6aPiM1H168fz39fm4oQ==",
+            "requires": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/octicons": {
+            "version": "10.47.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/octicons/-/octicons-10.47.0.tgz",
+            "integrity": "sha512-JOqEbwbh23u/AdaINod8ZeVN5MEcOvkSeMTwGIPaPgz5PNuWRj/+1LpixmBeZjAr/WhB0pxZBBwA+e91BelQCA==",
+            "requires": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/open-iconic": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/open-iconic/-/open-iconic-10.46.0.tgz",
+            "integrity": "sha512-v7wrHcUACQeSfJrLan/jXxgz7RSlJJXSc2u33UR82ewkOSBhaXp/zZxKF1tFCT2spvth0NBl6OkZUCw9ctgyrA==",
+            "requires": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/remix-editor": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/remix-editor/-/remix-editor-10.46.0.tgz",
+            "integrity": "sha512-oOrt6wj5//4LrZkm40bXcsFpTgXbdOkixu6RHuE3O82+Hqtw1bYR/smm5MbLOJ+Kz62SEjDF3sxqFO23ITDeUQ==",
+            "requires": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/remix-fill": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/remix-fill/-/remix-fill-10.46.0.tgz",
+            "integrity": "sha512-D2rWGJ9/7BR+3TMvmIoWGASMfyhWT4lTF+we8h9Pya5Ye+69cftvp817DMuaR/6czCugXTrB++HTQX0XJfoBFw==",
+            "requires": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/remix-line": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/remix-line/-/remix-line-10.46.0.tgz",
+            "integrity": "sha512-TkbtXdgcuM7VpE/51k8+sxfReFjSQpAFVnjJi8/gxwcTzjdOG7Plkgsaixi2+hiLk/Coj/+67KbntBoSevROsw==",
+            "requires": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/simple-icons": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/simple-icons/-/simple-icons-10.46.0.tgz",
+            "integrity": "sha512-zHkbGqAqFOwpqDjbhKTKsAXNxtBOXb7Ot2eKoDaDFckJGr2shAXRchclUS6wSixSPwQIPGAUcdO7Cq744Ollng==",
+            "requires": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/styled-icon": {
+            "version": "10.7.1",
+            "resolved": "https://registry.npmjs.org/@styled-icons/styled-icon/-/styled-icon-10.7.1.tgz",
+            "integrity": "sha512-WLYaeMTMhMkSxE+v+of+r2ovIk0tceDGfv8iqWHRMxvbm+6zxngVcQ4ELx6Zt/LFxqckmmoAdvo6ehiiYj6I6A==",
+            "requires": {
+                "@babel/runtime": "^7.20.7"
+            }
+        },
+        "@styled-icons/typicons": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/typicons/-/typicons-10.46.0.tgz",
+            "integrity": "sha512-yCJnVggGsbxOyuIPEmD+9IYRvB5w41hpJKdpI0ErasYG9Izt/lGqUaaDaxR39u9s28Q54Fq/v+Ni17dFCs8FOw==",
+            "requires": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
+        "@styled-icons/zondicons": {
+            "version": "10.46.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/zondicons/-/zondicons-10.46.0.tgz",
+            "integrity": "sha512-DUlww6TeFsFjHD/1qd+DtMutm44r3ssOYtPiMJrOVolX1NqdW6XzrJ5dTbVCA2s7Ucd+Vp25cWfXnLcJBfas3w==",
+            "requires": {
+                "@babel/runtime": "^7.19.0",
+                "@styled-icons/styled-icon": "^10.7.0"
+            }
+        },
         "@swc/helpers": {
             "version": "0.4.14",
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
@@ -4774,6 +6311,12 @@
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
             "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
             "dev": true
+        },
+        "@types/stylis": {
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.7.tgz",
+            "integrity": "sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==",
+            "peer": true
         },
         "@typescript-eslint/eslint-plugin": {
             "version": "5.52.0",
@@ -5161,6 +6704,12 @@
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
         },
+        "camelize": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+            "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+            "peer": true
+        },
         "caniuse-lite": {
             "version": "1.0.30001449",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001449.tgz",
@@ -5223,10 +6772,27 @@
                 "which": "^2.0.1"
             }
         },
+        "css-color-keywords": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+            "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+            "peer": true
+        },
+        "css-to-react-native": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+            "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+            "peer": true,
+            "requires": {
+                "camelize": "^1.0.0",
+                "css-color-keywords": "^1.0.0",
+                "postcss-value-parser": "^4.0.2"
+            }
+        },
         "csstype": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-            "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
         },
         "damerau-levenshtein": {
             "version": "1.0.8",
@@ -5283,6 +6849,11 @@
                 "has-property-descriptors": "^1.0.0",
                 "object-keys": "^1.1.1"
             }
+        },
+        "detect-node-es": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+            "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
         },
         "dir-glob": {
             "version": "3.0.1",
@@ -5875,6 +7446,11 @@
                 "has-symbols": "^1.0.3"
             }
         },
+        "get-nonce": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+            "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="
+        },
         "get-symbol-description": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
@@ -6443,9 +8019,9 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "nanoid": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -6646,9 +8222,9 @@
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
         },
         "picocolors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
         },
         "picomatch": {
             "version": "2.3.1",
@@ -6664,6 +8240,12 @@
                 "picocolors": "^1.0.0",
                 "source-map-js": "^1.0.2"
             }
+        },
+        "postcss-value-parser": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+            "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+            "peer": true
         },
         "prelude-ls": {
             "version": "1.2.1",
@@ -6733,6 +8315,52 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "react-number-format": {
+            "version": "5.4.4",
+            "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.4.4.tgz",
+            "integrity": "sha512-wOmoNZoOpvMminhifQYiYSTCLUDOiUbBunrMrMjA+dV52sY+vck1S4UhR6PkgnoCquvvMSeJjErXZ4qSaWCliA==",
+            "requires": {}
+        },
+        "react-remove-scroll": {
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+            "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+            "requires": {
+                "react-remove-scroll-bar": "^2.3.7",
+                "react-style-singleton": "^2.2.3",
+                "tslib": "^2.1.0",
+                "use-callback-ref": "^1.3.3",
+                "use-sidecar": "^1.1.3"
+            }
+        },
+        "react-remove-scroll-bar": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+            "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+            "requires": {
+                "react-style-singleton": "^2.2.2",
+                "tslib": "^2.0.0"
+            }
+        },
+        "react-style-singleton": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+            "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+            "requires": {
+                "get-nonce": "^1.0.0",
+                "tslib": "^2.0.0"
+            }
+        },
+        "react-textarea-autosize": {
+            "version": "8.5.9",
+            "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
+            "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
+            "requires": {
+                "@babel/runtime": "^7.20.13",
+                "use-composed-ref": "^1.3.0",
+                "use-latest": "^1.2.1"
+            }
         },
         "regenerator-runtime": {
             "version": "0.13.11",
@@ -6824,6 +8452,12 @@
                 "lru-cache": "^6.0.0"
             }
         },
+        "shallowequal": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+            "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+            "peer": true
+        },
         "shebang-command": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -6853,9 +8487,9 @@
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
         },
         "source-map-js": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
         },
         "stacktrace-parser": {
             "version": "0.1.10",
@@ -6933,6 +8567,81 @@
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
         },
+        "styled-components": {
+            "version": "6.3.8",
+            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.3.8.tgz",
+            "integrity": "sha512-Kq/W41AKQloOqKM39zfaMdJ4BcYDw/N5CIq4/GTI0YjU6pKcZ1KKhk6b4du0a+6RA9pIfOP/eu94Ge7cu+PDCA==",
+            "peer": true,
+            "requires": {
+                "@emotion/is-prop-valid": "1.4.0",
+                "@emotion/unitless": "0.10.0",
+                "@types/stylis": "4.2.7",
+                "css-to-react-native": "3.2.0",
+                "csstype": "3.2.3",
+                "postcss": "8.4.49",
+                "shallowequal": "1.1.0",
+                "stylis": "4.3.6",
+                "tslib": "2.8.1"
+            },
+            "dependencies": {
+                "postcss": {
+                    "version": "8.4.49",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+                    "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+                    "peer": true,
+                    "requires": {
+                        "nanoid": "^3.3.7",
+                        "picocolors": "^1.1.1",
+                        "source-map-js": "^1.2.1"
+                    }
+                }
+            }
+        },
+        "styled-icons": {
+            "version": "10.47.1",
+            "resolved": "https://registry.npmjs.org/styled-icons/-/styled-icons-10.47.1.tgz",
+            "integrity": "sha512-O6SguU8Z8Qk+rWJkiPmoLOxCQ3x8Emabue2r4NPqX+CK1uyaNahzFtKaGq/0d13RTWXqfVOBUSIJZaIlu4G/CA==",
+            "requires": {
+                "@babel/runtime": "^7.20.7",
+                "@styled-icons/bootstrap": "10.47.0",
+                "@styled-icons/boxicons-logos": "10.47.0",
+                "@styled-icons/boxicons-regular": "10.47.0",
+                "@styled-icons/boxicons-solid": "10.47.0",
+                "@styled-icons/crypto": "10.47.0",
+                "@styled-icons/entypo": "10.46.0",
+                "@styled-icons/entypo-social": "10.46.0",
+                "@styled-icons/evaicons-outline": "10.46.0",
+                "@styled-icons/evaicons-solid": "10.46.0",
+                "@styled-icons/evil": "10.46.0",
+                "@styled-icons/fa-brands": "10.47.0",
+                "@styled-icons/fa-regular": "10.47.0",
+                "@styled-icons/fa-solid": "10.47.0",
+                "@styled-icons/feather": "10.47.0",
+                "@styled-icons/fluentui-system-filled": "10.47.0",
+                "@styled-icons/fluentui-system-regular": "10.47.0",
+                "@styled-icons/foundation": "10.46.0",
+                "@styled-icons/heroicons-outline": "10.47.0",
+                "@styled-icons/heroicons-solid": "10.47.0",
+                "@styled-icons/icomoon": "10.46.0",
+                "@styled-icons/ionicons-outline": "10.46.0",
+                "@styled-icons/ionicons-sharp": "10.46.0",
+                "@styled-icons/ionicons-solid": "10.46.0",
+                "@styled-icons/material": "10.47.0",
+                "@styled-icons/material-outlined": "10.47.0",
+                "@styled-icons/material-rounded": "10.47.0",
+                "@styled-icons/material-sharp": "10.47.0",
+                "@styled-icons/material-twotone": "10.47.0",
+                "@styled-icons/octicons": "10.47.0",
+                "@styled-icons/open-iconic": "10.46.0",
+                "@styled-icons/remix-editor": "10.46.0",
+                "@styled-icons/remix-fill": "10.46.0",
+                "@styled-icons/remix-line": "10.46.0",
+                "@styled-icons/simple-icons": "10.46.0",
+                "@styled-icons/styled-icon": "10.7.1",
+                "@styled-icons/typicons": "10.46.0",
+                "@styled-icons/zondicons": "10.46.0"
+            }
+        },
         "styled-jsx": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
@@ -6940,6 +8649,12 @@
             "requires": {
                 "client-only": "0.0.1"
             }
+        },
+        "stylis": {
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+            "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+            "peer": true
         },
         "supports-color": {
             "version": "7.2.0",
@@ -6962,6 +8677,11 @@
                 "@pkgr/utils": "^2.3.1",
                 "tslib": "^2.5.0"
             }
+        },
+        "tabbable": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+            "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="
         },
         "tapable": {
             "version": "2.2.1",
@@ -7007,9 +8727,9 @@
             }
         },
         "tslib": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "tsutils": {
             "version": "3.21.0",
@@ -7050,9 +8770,9 @@
             }
         },
         "typescript": {
-            "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="
         },
         "unbox-primitive": {
             "version": "1.0.2",
@@ -7071,6 +8791,43 @@
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "requires": {
                 "punycode": "^2.1.0"
+            }
+        },
+        "use-callback-ref": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+            "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+            "requires": {
+                "tslib": "^2.0.0"
+            }
+        },
+        "use-composed-ref": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
+            "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
+            "requires": {}
+        },
+        "use-isomorphic-layout-effect": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+            "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+            "requires": {}
+        },
+        "use-latest": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
+            "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
+            "requires": {
+                "use-isomorphic-layout-effect": "^1.1.1"
+            }
+        },
+        "use-sidecar": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+            "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+            "requires": {
+                "detect-node-es": "^1.1.0",
+                "tslib": "^2.0.0"
             }
         },
         "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -12,23 +12,25 @@
         "lint": "next lint"
     },
     "dependencies": {
-        "@next/font": "13.1.6",
+        "@mantine/core": "^8.3.13",
+        "@mantine/hooks": "^8.3.13",
         "@sentry/nextjs": "^7.44.0",
-        "@types/node": "18.11.18",
+        "@types/node": "^24.0.0",
         "@types/react": "18.0.27",
         "@types/react-dom": "18.0.10",
         "@vercel/analytics": "^1.5.0",
         "clsx": "^1.2.1",
-        "eslint": "8.33.0",
         "eslint-config-next": "13.1.6",
         "next": "13.1.6",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-icons": "^4.7.1",
-        "typescript": "4.9.5"
+        "styled-icons": "^10.47.1",
+        "typescript": "^5.3.3"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.52.0",
+        "eslint": "8.33.0",
         "eslint-config-prettier": "^8.6.0",
         "prettier": "^2.8.4"
     }

--- a/src/contants.ts
+++ b/src/contants.ts
@@ -3,6 +3,7 @@ export const LINK_TO_RESUME =
 
 export const PATHS = {
     home: "/",
+    resume: "/resume",
 };
 
 export const ICON_SIZE = {

--- a/src/modules/common/CommonPageWrapper.tsx
+++ b/src/modules/common/CommonPageWrapper.tsx
@@ -1,15 +1,11 @@
-import React, { useState, useMemo } from "react";
+import React, { useState } from "react";
 import { clsx } from "clsx";
 import { FaHamburger } from "react-icons/fa";
 import { IoClose } from "react-icons/io5";
-import Link from "next/link";
-import Image from "next/image";
 import styles from "../../styles/CommonPageWrapper.module.css";
-import { ICON_SIZE, LINK_TO_RESUME } from "@/contants";
-import ObaLogo from "../../../public/images/obase_logo.png";
-import ObaLogoDark from "../../../public/images/obase_logo_dark.png";
+import { ICON_SIZE, PATHS } from "@/contants";
 import { HOME_PAGE_ANCHORS } from "@/constants/homeConstants";
-import { useTheme } from "./ThemeManager";
+import { HeaderLogo } from "./HeaderLogo";
 
 interface ICommonPageWrapperProps {
 	children: React.ReactNode;
@@ -19,24 +15,18 @@ export const CommonPageWrapper: React.FC<ICommonPageWrapperProps> = ({
 	children,
 }) => {
 	const [isSideBarOpen, setIsSideBarOpen] = useState(false);
-	const { isLightTheme } = useTheme();
-
-	const Logo = useMemo(() => (isLightTheme ? ObaLogoDark : ObaLogo), [isLightTheme]);
-
 
 	return (
 		<div>
 			<div className={styles.header}>
 				<nav className={styles.navBar}>
 					<div className={styles.logoWrapper}>
-						<Link href="/">
-							<Image priority src={Logo} className={styles.logo} alt="" />
-						</Link>
+						<HeaderLogo className={styles.logo} />
 					</div>
 					<div id="navRow">
 						<NavLinks />
 					</div>
-					<div id="hamburgerMenu">
+					<div className={styles.hamburgerMenu}>
 						<FaHamburger
 							size={ICON_SIZE.large}
 							onClick={() => setIsSideBarOpen(true)}
@@ -78,8 +68,7 @@ const NavLinks = () => (
 			Projects
 		</a>
 		<a
-			target="_blank"
-			href={LINK_TO_RESUME}
+			href={PATHS.resume}
 			className={styles.navLink}
 			rel="noreferrer"
 		>

--- a/src/modules/common/HeaderLogo.tsx
+++ b/src/modules/common/HeaderLogo.tsx
@@ -1,0 +1,24 @@
+import React, { useMemo } from "react";
+import Link from "next/link";
+import Image, { ImageProps } from "next/image";
+import ObaLogo from "../../../public/images/obase_logo.png";
+import ObaLogoDark from "../../../public/images/obase_logo_dark.png";
+import { useTheme } from "./ThemeManager";
+
+
+export function HeaderLogo({ className, ...props }: { className?: string } & Omit<ImageProps, "src" | "alt">) {
+    const { isLightTheme } = useTheme();
+
+    const Logo = useMemo(() => (isLightTheme ? ObaLogoDark : ObaLogo), [isLightTheme]);
+
+    return (
+        <Link href="/" style={{
+            display: "inline-block",
+            lineHeight: 0,
+            padding: 0,
+            margin: 0,
+        }}>
+            <Image priority src={Logo} className={className} alt="" {...props} />
+        </Link >
+    )
+}

--- a/src/modules/resume/ResumePage.constants.tsx
+++ b/src/modules/resume/ResumePage.constants.tsx
@@ -1,0 +1,258 @@
+import { ResumeType } from "./ResumePage.types";
+
+export const RESUME: ResumeType = {
+    header: {
+        name: "Obatola Seward-Evans",
+        items: [
+            { icon: "Call", content: "510 459 8051" },
+            { icon: "Mail", content: "oba.seward@gmail.com" },
+            { icon: "Link", content: "linkedin.com/in/obatola | obase.weebly.com" },
+            { icon: "Location", content: "Brooklyn, NY" },
+        ]
+    },
+    mainPanel: [
+        {
+            title: "About Me",
+            content: [
+                {
+                    type: 'generic',
+                    children: (
+                        <p>
+                            I&apos;m a frontend engineer. I have a passion for creating clean, intuitive,
+                            and elegant user flows, designs, applications and code.
+                        </p>
+                    )
+                }
+            ]
+        },
+        {
+            title: "Experience",
+            content: [
+                {
+                    type: 'experience',
+                    title: "Software Engineer",
+                    company: "DoorDash",
+                    date: "06/2021 - 09/2022",
+                    location: "San Francisco Bay Area",
+                    children: (
+                        <>
+                            <p>
+                                DoorDash is a global online food ordering and food delivery platform
+                            </p>
+                            <ul>
+                                <li>
+                                    When joining, the login and sign up page was minimally maintained,
+                                    poorly tested, and lead to convoluted development.
+                                </li>
+                                <li>
+                                    Took over the login and sign up web app and redesigned the internal
+                                    code base to increase developer velocity by 60% and increase site
+                                    speed by 5% using React JS and Typescript
+                                </li>
+                                <li>
+                                    Added E2E testing to improve trust of the project / code /
+                                    deployments
+                                </li>
+                                <li>
+                                    Added experimental features that lead to over $1,000,000 in annual
+                                    revenue
+                                </li>
+                                <li>
+                                    In order to alleviate the frustrations of legitimate customers who
+                                    are having trouble logging in, we implemented a Bypass Login
+                                    feature that lead to a $700k annual lift in orders.
+                                </li>
+                                <li>
+                                    Created a guided sign up and login flow to guide users attempting
+                                    to log in with unknown accounts and users attempting to sign up
+                                    with known accounts down the right path. This lead to a 2.7% lift
+                                    in user logins and signups.
+                                </li>
+                            </ul>
+                        </>
+                    )
+                },
+                {
+                    type: 'experience',
+                    title: "Software Engineer II",
+                    company: "Shape Security",
+                    date: "02/2018 - 05/2021",
+                    location: "San Francisco Bay Area",
+                    children: (
+                        <>
+                            <p>
+                                Shape Security provides best-in-class cybersecurity to protect your
+                                enterprise from automated attacks on web and mobile apps
+                            </p>
+                            <ul>
+                                <li>
+                                    Designed and developed features for Shape&apos;s web protection dashboard
+                                    to customize Shape&apos;s security solutions as well as visualize,
+                                    analyze, and comprehend real-time traffic and attack patterns
+                                </li>
+                                <li>
+                                    Worked with Google Cloud Function and Google App Engine to create a
+                                    scheduled report downloader, to automate previously manually
+                                    generated weekly reports
+                                </li>
+                                <li>
+                                    Implemented security-sensitive features such as Domain Whitelist
+                                    Validation and User Session Timeout to better secure the web
+                                    dashboard
+                                </li>
+                                <li>
+                                    Built Chrome Extension in React, NodeJS to interact with their main
+                                    platform to simulate web entries
+                                </li>
+                            </ul>
+                        </>
+                    )
+                },
+                {
+                    type: 'experience',
+                    title: "Data Engineering Intern",
+                    company: "Optum",
+                    date: "06/2017 - 08/2017",
+                    location: "Boston, MA",
+                    children: (
+                        <>
+                            <p>Optum helps modernize the health system&apos;s infrastructure.</p>
+                            <ul>
+                                <li>
+                                    Transformed the existing Oracle SQL based ETL process to Spark on
+                                    Hadoop to accelerate the process and scalability of electronic
+                                    medical records
+                                </li>
+                                <li>
+                                    Reached 300% increase in time to create and complete an ETL spec
+                                </li>
+                            </ul>
+                        </>
+                    )
+                },
+                {
+                    type: 'experience',
+                    title: "iOS Developer",
+                    company: "Step Champion",
+                    date: "06/2016 - 10/2016",
+                    location: "San Francisco Bay Area",
+                    children: (
+                        <>
+                            <ul>
+                                <li>
+                                    Served as a front-end mobile iOS developer to build UI and connect
+                                    it to back-end. Created new icon and color manager to handle
+                                    different themes.
+                                </li>
+                            </ul>
+                        </>
+                    )
+                },
+            ]
+        },
+    ],
+    rightPanel: [
+        {
+            title: "Technologies",
+            content: [
+                {
+                    type: 'technologies',
+                    technologies: ["ReactJS", "Typescript", "Javascript", "NodeJS", "GCP", "Java", "Python", "HTML / CSS"]
+                }
+            ]
+        },
+        {
+            title: "Achievements",
+            content: [
+                {
+                    type: 'achievements',
+                    achievements:
+                        [
+                            { icon: "Code", content: "Upsilon Pi Epsilon (International Computer Science Honors Society)" },
+                            { icon: "Hammer", content: "Eagle Scout in the Boy Scouts of America" },
+                        ]
+                }
+            ]
+        },
+        {
+            title: "Projects",
+            content: [
+                {
+                    type: 'project',
+                    title: "Personal Website",
+                    url: "https://www.obatola.com/",
+                    children: (
+                        <>
+                            <p>
+                                Designed personal website in Sketch and implemented using NextJS.
+                                Used as a location showcase my work and a quick place to spin up
+                                small test projects.
+                            </p>
+                        </>
+                    )
+                },
+                {
+                    type: 'project',
+                    title: "Dice Roller",
+                    url: "https://obatola.github.io/dice/",
+                    children: (
+                        <>
+                            <p>Website created to allow people roll sets of die.</p>
+                            <ul>
+                                <li>
+                                    Allows users to pick from a range of dice, customize color and save
+                                    sets for use later
+                                </li>
+                                <li>Created using React and hosted on github using gh-pages</li>
+                            </ul>
+                        </>
+                    )
+                },
+                {
+                    type: 'project',
+                    title: "Data Collection Website - AngularJS",
+                    url: "tiny.cc/ve-collect",
+                    children: (
+                        <>
+                            <ul>
+                                <li>
+                                    Website created to help users collect information about over 180
+                                    Venetian Bell Towers in Venice, Italy
+                                </li>
+                                <li>Created using AngularJS interfacing with Firebase</li>
+                            </ul>
+                        </>
+                    )
+                }
+            ]
+        },
+        {
+            title: "Education",
+            content: [
+                {
+                    type: 'education',
+                    degree: "Bachelor of Science in Computer Science",
+                    school: "Worcester Polytechnic Institute (WPI)",
+                    date: "08/2014 - 05/2018",
+                    gpa: "3.66 / 4"
+                }
+            ]
+        },
+        {
+            title: "Courses",
+            content: [
+                {
+                    type: 'generic',
+                    children: (
+                        <p>
+                            Software Engineering, Algorithms, Object-Oriented Design Concepts,
+                            Mobile &amp; Ubiquitous Computing, Artificial Intelligence, Database
+                            Systems, Computer Networks, Operating Systems, Systems Programming,
+                            Privacy Protection Technology
+                        </p>
+                    )
+                }
+            ]
+        }
+    ]
+}

--- a/src/modules/resume/ResumePage.module.css
+++ b/src/modules/resume/ResumePage.module.css
@@ -1,0 +1,148 @@
+.resume-page-container {
+  padding: 0 0 15pt 0;
+}
+
+/* Reset all default styles - scoped to resume page only */
+.resume-page-container h1,
+.resume-page-container h2,
+.resume-page-container h3,
+.resume-page-container h4,
+.resume-page-container h5,
+.resume-page-container p,
+.resume-page-container section,
+.resume-page-container ul,
+.resume-page-container li {
+  line-height: 1.3;
+  margin: 0;
+  padding: 0;
+}
+
+.resume-page__logo-wrapper {
+  display: flex;
+  justify-content: start;
+  align-items: center;
+  width: 100%;
+  padding: 10px 15px;
+}
+
+.resume-page__resume {
+  width: 8.5in;
+  min-height: 11in;
+  max-width: 100%;
+
+  background-color: var(--resume-color-paper-background);
+  box-shadow: 0 0 1.5pt 0 rgba(83, 83, 83, 0.5);
+
+  /* Approximate ANSI A (8.5in x 11in) with standard margins */
+  box-sizing: border-box;
+
+  /* Common print-style margins: ~1in around the page */
+  padding: var(--resume-margin-x) var(--resume-margin-y);
+  margin: 0 auto;
+
+  font-family: var(--resume-font-normal);
+  font-size: 10.5pt;
+  color: var(--resume-color-text);
+}
+
+.resume-page__resume h1 {
+  font-family: var(--resume-font-decorative);
+  font-weight: 500;
+  font-size: 23pt;
+  line-height: 28pt;
+  color: var(--resume-color-text-primary);
+}
+
+.resume-page__resume h2 {
+  font-family: var(--resume-font-decorative);
+  font-weight: 400;
+  font-size: 8pt;
+  line-height: 15pt;
+  text-transform: uppercase;
+  color: var(--resume-color-text-secondary);
+}
+
+.resume-page__resume h3 {
+  font-size: 13.5pt;
+  font-weight: 400;
+  line-height: 12pt;
+  color: var(--resume-color-text-primary);
+  font-family: var(--resume-font-decorative);
+}
+
+.resume-page__resume h4 {
+  font-size: 11pt;
+  font-weight: 500;
+  font-family: var(--resume-font-decorative);
+}
+
+.resume-page__resume li {
+  margin-left: 12pt;
+}
+
+.resume-page__caption {
+  font-size: 9pt;
+  font-weight: 300;
+  color: var(--resume-color-text-secondary);
+}
+
+.resume-page__header-item {
+  font-size: 10pt;
+}
+
+.resume-page__accented-text {
+  color: var(--resume-color-text-accented);
+}
+
+.resume-page__technology {
+  padding: 0 4.5pt;
+  font-family: var(--resume-font-decorative);
+  font-weight: 600;
+  font-size: 9pt;
+  color: var(--resume-color-text);
+  border-bottom: 1px solid var(--resume-color-text);
+}
+
+.resume-page__achievement p {
+  font-family: var(--resume-font-decorative);
+  font-weight: 500;
+}
+
+.resume-page__icon {
+  color: var(--resume-color-icon);
+  height: 10.5pt;
+}
+
+@media print {
+  @page {
+    size: letter; /* ANSI A (8.5in x 11in) */
+    margin: var(--resume-margin-x) var(--resume-margin-y);
+  }
+
+  .resume-page__resume-wrapper {
+    width: 100%;
+    margin: 0;
+    padding: 0;
+  }
+
+  .resume-page__resume {
+    width: 100%;
+    height: auto;
+    margin: 0;
+    padding: 0;
+    box-shadow: none;
+  }
+
+  .resume-page__logo-wrapper {
+    display: none;
+  }
+
+  .resume-page-container h1,
+  .resume-page-container h2,
+  .resume-page-container h3,
+  .resume-page-container h4,
+  .resume-page-container h5,
+  .resume-page-container article {
+    page-break-inside: avoid;
+  }
+}

--- a/src/modules/resume/ResumePage.tsx
+++ b/src/modules/resume/ResumePage.tsx
@@ -1,0 +1,187 @@
+import { Center, Grid, Group, Stack } from "@mantine/core";
+import classes from "./ResumePage.module.css";
+import * as Icons from "@styled-icons/ionicons-solid";
+import type { ResumeAchievementsType, ResumeEducationType, ResumeExperienceType, ResumeHeaderType, ResumeProjectType, ResumeTechnologiesType, ResumeType, SectionType } from "./ResumePage.types";
+import { HeaderLogo } from "../common/HeaderLogo";
+
+const SPACING = {
+    none: 0,
+    sm: 4,
+    md: 8,
+    lg: 12,
+    xl: 16,
+}
+
+function Icon({ icon }: { icon: keyof typeof Icons }) {
+    if (!Icons[icon]) {
+        return null;
+    }
+    const IconComponent = Icons[icon];
+
+    return <Center className={classes["resume-page__icon"]}><IconComponent strokeWidth={3} className={classes["resume-page__icon"]} /></Center>
+}
+
+function Header({
+    name,
+    items,
+}: ResumeHeaderType) {
+    return (
+        <section>
+            <Stack gap={SPACING.sm}>
+                <h1>{name}</h1>
+                <Group gap={SPACING.lg}>
+                    {items.map((item) => (
+                        <Group key={item.icon} gap={SPACING.sm} className={classes["resume-page__header-item"]}>
+                            <Icon icon={item.icon} />
+                            <p>{item.content}</p>
+                        </Group>
+                    ))}
+                </Group>
+            </Stack>
+        </section>
+    )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+    return (
+        <section>
+            <h2>{title}</h2>
+            {children}
+        </section>
+    )
+}
+
+function Experience({ title, company, date, location, children }: ResumeExperienceType) {
+    return (
+        <article>
+            <Stack gap={SPACING.none}>
+                <h3>{title}</h3>
+                <Group gap={SPACING.lg} align="baseline">
+                    <h4 className={classes["resume-page__accented-text"]}>{company}</h4>
+                    <p className={classes["resume-page__caption"]}>{date}</p>
+                    <p className={classes["resume-page__caption"]}>{location}</p>
+                </Group>
+            </Stack>
+            {children}
+        </article>
+    )
+}
+
+function Technologies({ technologies }: ResumeTechnologiesType) {
+    return (
+        <article>
+            <Group gap={SPACING.md}>
+                {technologies.map((technology) => (
+                    <p key={technology} className={classes["resume-page__technology"]}>{technology}</p>
+                ))}
+            </Group>
+        </article>
+    )
+}
+
+function Achievements({ achievements }: ResumeAchievementsType) {
+    return (
+        <article>
+            <Group gap={SPACING.md}>
+                {achievements.map((achievement) => (
+                    <Group key={achievement.icon} gap={SPACING.md} wrap="nowrap" align="start" className={classes["resume-page__achievement"]}>
+                        <Icon icon={achievement.icon} />
+                        <p>{achievement.content}</p>
+                    </Group>
+                ))}
+            </Group>
+        </article>
+    )
+}
+
+function Project({ title, url, children }: ResumeProjectType) {
+    return (
+        <article>
+            <Stack gap={SPACING.sm}>
+                <h3>{title}</h3>
+                <p className={classes["resume-page__caption"]}>{url}</p>
+            </Stack>
+            {children}
+        </article>
+    )
+}
+
+function Education({ degree, school, date, gpa }: ResumeEducationType) {
+    return (
+        <article>
+            <Stack gap={SPACING.sm}>
+                <Stack gap={SPACING.sm}>
+                    <Stack gap={SPACING.none}>
+                        <h3>{degree}</h3>
+                        <h4 className={classes["resume-page__accented-text"]}>{school}</h4>
+                    </Stack>
+                    <Group gap={SPACING.lg}>
+                        <p className={classes["resume-page__caption"]}>{date}</p>
+                        <p>GPA: {gpa}</p>
+                    </Group>
+                </Stack>
+            </Stack>
+        </article >
+    )
+}
+
+
+function DynamicSection({ title, content }: SectionType) {
+    const contentDOM = content.map((item, index) => {
+        switch (item.type) {
+            case 'generic':
+                return <div key={index}>{item.children}</div>;
+            case 'experience':
+                return <Experience key={index} {...item} />;
+            case 'technologies':
+                return <Technologies key={index} {...item} />;
+            case 'achievements':
+                return <Achievements key={index} {...item} />;
+            case 'project':
+                return <Project key={index} {...item} />;
+            case 'education':
+                return <Education key={index} {...item} />;
+            default:
+                return null;
+        }
+    })
+    return (
+        <Section title={title}>
+            <Stack gap={SPACING.xl}>
+                {contentDOM}
+            </Stack>
+        </Section>
+    )
+}
+
+export function DynamicResumePage({ resume }: { resume: ResumeType }) {
+    const mainPanelDOM = resume.mainPanel.map((item) => <DynamicSection key={item.title} {...item} />)
+    const rightPanelDOM = resume.rightPanel.map((item) => <DynamicSection key={item.title} {...item} />)
+
+    return (
+        <div className={classes["resume-page-container"]}>
+            <div className={classes["resume-page__logo-wrapper"]}>
+                <HeaderLogo height={25} />
+            </div>
+            <div className={classes["resume-page__resume-wrapper"]}>
+                <div className={classes["resume-page__resume"]}>
+                    <Stack>
+                        <Header {...resume.header} />
+                        <Grid gutter={14}>
+                            <Grid.Col span={{ base: 12, xs: 7 }}>
+                                <Stack gap={SPACING.xl}>
+                                    {mainPanelDOM}
+                                </Stack>
+                            </Grid.Col>
+                            <Grid.Col span={{ base: 12, xs: 5 }}>
+                                <Stack gap={SPACING.xl}>
+                                    {rightPanelDOM}
+                                </Stack>
+                            </Grid.Col>
+                        </Grid>
+                    </Stack>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/modules/resume/ResumePage.types.ts
+++ b/src/modules/resume/ResumePage.types.ts
@@ -1,0 +1,62 @@
+import * as Icons from "@styled-icons/ionicons-solid";
+
+export type ResumeHeaderType = {
+    name: string;
+    items: {
+        icon: keyof typeof Icons;
+        content: string;
+    }[]
+}
+
+export type ResumeExperienceType = {
+    title: string;
+    company: string;
+    date: string;
+    location: string;
+    children: React.ReactNode;
+}
+
+export type ResumeTechnologiesType = {
+    technologies: string[];
+}
+
+export type ResumeAchievementsType = {
+    achievements: {
+        icon: keyof typeof Icons;
+        content: string;
+    }[];
+}
+
+export type ResumeProjectType = {
+    title: string;
+    url: string;
+    children: React.ReactNode;
+}
+
+export type ResumeEducationType = {
+    degree: string;
+    school: string;
+    date: string;
+    gpa: string;
+}
+
+type SectionContentType =
+    (ResumeExperienceType & {type: 'experience'}) | 
+    (ResumeTechnologiesType & {type: 'technologies'}) |
+    (ResumeAchievementsType & {type: 'achievements'}) |
+    (ResumeProjectType & {type: 'project'}) |
+    (ResumeEducationType & {type: 'education'}) |
+    ({children: React.ReactNode} & {type: 'generic'})
+
+
+export type SectionType = {
+    title: string;
+    content: SectionContentType[];
+}
+
+
+export type ResumeType = {
+    header: ResumeHeaderType;
+    mainPanel: SectionType[];
+    rightPanel: SectionType[];
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,11 +1,18 @@
+import '@mantine/core/styles.css';
 import "@/styles/globals.css";
 import "@/styles/globalsMidnight.css";
 import "@/styles/globalsDark.css";
 import "@/styles/globalsLight.css";
 import "@/styles/globalsTerminalGreen.css";
+import "@/styles/resume.css";
 
 import type { AppProps } from "next/app";
+import { MantineProvider } from "@mantine/core";
 
 export default function App({ Component, pageProps }: AppProps) {
-	return <Component {...pageProps} />;
+	return (
+		<MantineProvider defaultColorScheme="light">
+			<Component {...pageProps} />
+		</MantineProvider>
+	);
 }

--- a/src/pages/resume/index.tsx
+++ b/src/pages/resume/index.tsx
@@ -1,0 +1,23 @@
+import Head from "next/head";
+import { ThemeProvider } from "@/modules/common/ThemeManager";
+import { Analytics } from "@vercel/analytics/react"
+import { DynamicResumePage } from "@/modules/resume/ResumePage";
+import { RESUME } from "@/modules/resume/ResumePage.constants";
+
+export default function Resume() {
+    return (
+        <ThemeProvider>
+            <Analytics />
+            <Head>
+                <title>Resume - Oba</title>
+                <meta name="description" content="Obatola Seward-Evans Resume" />
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+                <link rel="manifest" href="/home.webmanifest" />
+                <link rel="icon" href="/favicon.ico" />
+            </Head>
+            <main>
+                <DynamicResumePage resume={RESUME} />
+            </main>
+        </ThemeProvider>
+    );
+}

--- a/src/styles/CommonPageWrapper.module.css
+++ b/src/styles/CommonPageWrapper.module.css
@@ -30,6 +30,12 @@
     width: auto;
 }
 
+.hamburgerMenu {
+    line-height: 0;
+    padding: 0;
+    margin: 0;
+}
+
 .navBar {
     display: flex;
     padding: 0 50px;
@@ -40,7 +46,7 @@
     height: var(--nav-height);
 }
 
-.navBar :global(#hamburgerMenu) {
+.navBar .hamburgerMenu {
     display: none;
 }
 
@@ -128,7 +134,7 @@
         display: none;
     }
 
-    .navBar :global(#hamburgerMenu) {
+    .navBar .hamburgerMenu {
         display: block;
     }
 

--- a/src/styles/ThemeManager.module.css
+++ b/src/styles/ThemeManager.module.css
@@ -55,3 +55,9 @@
 .theme-manager__theme-button__accent-box--active {
     box-shadow: 0 0 10px 3px var(--colors-primary);
 }
+
+@media print {
+    .theme-manager__container {
+        display: none;
+    }
+}

--- a/src/styles/resume.css
+++ b/src/styles/resume.css
@@ -1,0 +1,17 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@100..900&display=swap');
+
+:root {
+  --resume-font-decorative: "Roboto Slab", Arial, Helvetica, "Noto Sans Devanagari", "Noto Sans CJK SC Thin", "Noto Sans SC", "Noto Sans Hebrew", "Noto Sans Bengali", sans-serif;
+  --resume-font-normal: "Open Sans", Arial, Helvetica, "Noto Sans Devanagari", "Noto Sans CJK SC Thin", "Noto Sans SC", "Noto Sans Hebrew", "Noto Sans Bengali", sans-serif;
+
+  --resume-color-site-background: #fafbfd;
+  --resume-color-paper-background: white;
+  --resume-color-text: #3e3e3e;
+  --resume-color-text-primary: #000000;
+  --resume-color-text-secondary: #60696c;
+  --resume-color-icon: #b9b9b9;
+  --resume-color-text-accented: #3d8af7;
+
+  --resume-margin-x: 0.5in;
+  --resume-margin-y: 0.7in;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a self-contained, print-friendly resume experience and integrates supporting UI changes.
> 
> - New dynamic resume feature: `src/pages/resume`, `ResumePage.tsx/.types.ts`, and `ResumePage.constants.tsx` render structured resume content with Mantine layout and styled-icons
> - Global UI setup: wraps app in `MantineProvider` and imports Mantine/Resume styles; adds `resume.css` and scoped `ResumePage.module.css` with print media rules
> - Navigation/logo refactor: adds `HeaderLogo` component (theme-aware) and updates `CommonPageWrapper` to use it; replaces external resume link with internal `PATHS.resume`; adds `PATHS.resume` constant
> - Minor style tweaks: hamburger menu class and print-hiding ThemeManager
> - Tooling/deps: add `@mantine/core`, `@mantine/hooks`, `styled-icons`; bump TypeScript and `@types/node`; VS Code eslint-on-save set to "explicit"
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21460226852c462f38fea3d3cfd15e21de7ffadd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->